### PR TITLE
add requirement.txt into .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,5 @@
 *
 !*.py
+!requirements.txt
 !requirements.lock
 !templates


### PR DESCRIPTION
fixes` ModuleNotFoundError: No module named 'dotenv'`